### PR TITLE
Allow ssh to execute itself

### DIFF
--- a/profiles/ssh
+++ b/profiles/ssh
@@ -14,7 +14,7 @@ profile ssh /usr/bin/ssh {
   # Executables
   /usr/bin/{bash,dash} mrix,
   /usr/bin/env r,
-  /usr/bin/ssh r,
+  /usr/bin/ssh rix,
 
   # Mosh
   /usr/bin/mosh rPx,


### PR DESCRIPTION
This is used for ssh -J (ProxyJump).

Previously, `ssh -J user@jumphost user@192.168.1.196` gave an error message by ssh and:
```
apparmor="DENIED" operation="exec" class="file" profile="ssh" name="/usr/bin/ssh" pid=209228 comm="bash" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0
```